### PR TITLE
fix: positional arguments missing on sync client __exit__ method #14

### DIFF
--- a/telepay/v1/_async/client.py
+++ b/telepay/v1/_async/client.py
@@ -34,7 +34,7 @@ class TelePayAsyncClient:
     async def __aenter__(self) -> "TelePayAsyncClient":
         return self
 
-    async def __aexit__(self, exc_t, exc_v, exc_tb) -> None:
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         await self.close()
 
     async def close(self) -> None:

--- a/telepay/v1/_sync/client.py
+++ b/telepay/v1/_sync/client.py
@@ -34,7 +34,7 @@ class TelePaySyncClient:
     def __enter__(self) -> "TelePaySyncClient":
         return self
 
-    def __exit__(self) -> None:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
 
     def close(self) -> None:


### PR DESCRIPTION
closes #14